### PR TITLE
Check if suffix is zero state earlier

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,19 +52,30 @@ I also added measurements for the pure python libraries with run with pypy.
 
 These are the results:
 
-| Library (Variant)                                  | Setup (1x) | Search (100x) |
-|----------------------------------------------------|------------|---------------|
-| ahocorapy                                          | 1.2s       | 1.76s         |
-| ahocorapy (run with pypy)                          | 0.9s       | 0.09s         |
-| pyahocorasick                                      | 0.1s       | 0.06s         |
-| pyahocorasick (pure python variant in github repo) | 0.5s       | 1.68s         |
-| py_aho_corasick                                    | 1.9s       | 13.2s         |
-| py_aho_corasick (run with pypy)                    | 1.3s       | 3.71s         |
+| Library (Variant)                                    | Setup (1x)  | Search (100x) |
+|------------------------------------------------------|-------------|---------------|
+| ahocorapy*                                           | 0.33s       | 0.51s         |
+| ahocorapy (run with pypy)*                           | 0.37s       | 0.10s         |
+| pyahocorasick*                                       | 0.03s       | 0.04s         |
+| pyahocorasick (run with pypy)*                       | 0.08s       | 0.04s         |
+| pyahocorasick (pure python variant in github repo)** | 0.50s       | 1.68s         |
+| py_aho_corasick*                                     | 0.82s       | 6.80s         |
+| py_aho_corasick (run with pypy)*                     | 0.70s       | 2.01s         |
 
 As expected the C-Extension shatters the pure python implementations. Even though there is probably still room for optimization in
 ahocorapy we are not going to get to the mark that pyahocorasick sets. ahocorapy's lookups are faster than py_aho_corasick. 
-When run with pypy [PyPy 5.1.2 with GCC 5.3.1 20160413] ahocorapy is almost as fast as pyahocorasick, at least when it comes to
+When run with pypy ahocorapy is almost as fast as pyahocorasick, at least when it comes to
 searching. The setup overhead is higher due to the suffix shortcutting mechanism used.
+
+\* Specs
+
+Dell XPS 15 7590  
+CPU: Intel i9-9980HK (16) @ 5.000GHz  
+CPython: 3.8.2  
+pypy: PyPy 7.3.1 with GCC 7.3.1 20180303  
+Date tested: 2020-08-19  
+
+\** Old measurement with different specs
 
 
 ## Basic Usage:

--- a/src/ahocorapy/keywordtree.py
+++ b/src/ahocorapy/keywordtree.py
@@ -162,11 +162,12 @@ class KeywordTree(object):
                 else:
                     traversed = traversed.longest_strict_suffix
             suffix = state.longest_strict_suffix
+            if suffix == self._zero_state:
+                return
             if suffix.longest_strict_suffix is None:
                 self.search_lss(suffix)
             for symbol, next_state in suffix.transitions.items():
-                if (symbol not in state.transitions and
-                        suffix != self._zero_state):
+                if symbol not in state.transitions:
                     state.transitions[symbol] = next_state
 
     def __str__(self):

--- a/src/ahocorapy/keywordtree.py
+++ b/src/ahocorapy/keywordtree.py
@@ -147,28 +147,27 @@ class KeywordTree(object):
                     to_process.append(child)
 
     def search_lss(self, state):
-        if state.longest_strict_suffix is None:
-            parent = state.parent
-            traversed = parent.longest_strict_suffix
-            while True:
-                if state.symbol in traversed.transitions and\
-                        traversed.transitions[state.symbol] != state:
-                    state.longest_strict_suffix =\
-                        traversed.transitions[state.symbol]
-                    break
-                elif traversed == self._zero_state:
-                    state.longest_strict_suffix = self._zero_state
-                    break
-                else:
-                    traversed = traversed.longest_strict_suffix
-            suffix = state.longest_strict_suffix
-            if suffix == self._zero_state:
-                return
-            if suffix.longest_strict_suffix is None:
-                self.search_lss(suffix)
-            for symbol, next_state in suffix.transitions.items():
-                if symbol not in state.transitions:
-                    state.transitions[symbol] = next_state
+        parent = state.parent
+        traversed = parent.longest_strict_suffix
+        while True:
+            if state.symbol in traversed.transitions and\
+                    traversed.transitions[state.symbol] != state:
+                state.longest_strict_suffix =\
+                    traversed.transitions[state.symbol]
+                break
+            elif traversed == self._zero_state:
+                state.longest_strict_suffix = self._zero_state
+                break
+            else:
+                traversed = traversed.longest_strict_suffix
+        suffix = state.longest_strict_suffix
+        if suffix == self._zero_state:
+            return
+        if suffix.longest_strict_suffix is None:
+            self.search_lss(suffix)
+        for symbol, next_state in suffix.transitions.items():
+            if symbol not in state.transitions:
+                state.transitions[symbol] = next_state
 
     def __str__(self):
         return "ahocorapy KeywordTree"


### PR DESCRIPTION
That check never had to be in the loop.
Moving it to the earlier place improves setup performance significantly.

Running the performance test on my dev machine shows the following.

Before this PR:
```
----------ahocorapy----------
setup_ahocorapy: 0.5499229790002573
search_ahocorapy: 0.5603391219920013
```

With this PR:
```
----------ahocorapy----------
setup_ahocorapy: 0.3339365099964198
search_ahocorapy: 0.5498242719913833
```

As you can see this is an improvement of almost 40% in setup/finalization.

These tests were run using cpython 3.8
I should use this opportunity to also update (most of) the measurements